### PR TITLE
0.41.2 - fix langspec

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algorandfoundation/tealscript",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "Enables Algorand smart contract development with native TypeScript syntax, tooling, and IDE support",
   "homepage": "https://github.com/algorand-devrel/TEALScript",
   "bugs": {


### PR DESCRIPTION
* moves langspec to `dist/` (caused by change to use `readFileSync` rather than Typescript JSON import)