### PR TITLE
Add v10 globals

### DIFF
--- a/src/static/langspec.json
+++ b/src/static/langspec.json
@@ -1,6 +1,6 @@
 {
   "Version": 10,
-  "LogicSigVersion": 9,
+  "LogicSigVersion": 10,
   "NamedTypes": [
     {
       "Name": "[32]byte",
@@ -1196,7 +1196,8 @@
         "CallerApplicationID",
         "CallerApplicationAddress",
         "AssetCreateMinBalance",
-        "AssetOptInMinBalance"
+        "AssetOptInMinBalance",
+        "GenesisHash"
       ],
       "ArgEnumTypes": [
         "uint64",
@@ -1215,7 +1216,8 @@
         "uint64",
         "address",
         "uint64",
-        "uint64"
+        "uint64",
+        "[32]byte"
       ],
       "DocCost": "1",
       "Doc": "global field F",

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -686,13 +686,13 @@ declare const globals: {
   currentApplicationID: Application;
   creatorAddress: Address;
   currentApplicationAddress: Address;
-  groupID: bytes;
+  groupID: bytes32;
   opcodeBudget: uint64;
   callerApplicationID: Application;
   callerApplicationAddress: Address;
   assetCreateMinBalance: uint64;
   assetOptInMinBalance: uint64;
-  genesisHash: bytes;
+  genesisHash: bytes32;
 };
 
 /** Get information from the given block.

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -690,6 +690,9 @@ declare const globals: {
   opcodeBudget: uint64;
   callerApplicationID: Application;
   callerApplicationAddress: Address;
+  assetCreateMinBalance: uint64;
+  assetOptInMinBalance: uint64;
+  genesisHash: bytes;
 };
 
 /** Get information from the given block.


### PR DESCRIPTION
I set `genesisHash` to be `bytes` to match the others. But is there a reason we don't use `bytes32` for this and groupID?