### PR TITLE
fix: arc56 AVMBytes for state keys

### DIFF
--- a/examples/reti/artifacts/StakingPool.arc56_draft.json
+++ b/examples/reti/artifacts/StakingPool.arc56_draft.json
@@ -452,7 +452,7 @@
         "algodVer": {
           "key": "YWxnb2RWZXI=",
           "keyType": "AVMBytes",
-          "valueType": "byte[]"
+          "valueType": "AVMBytes"
         },
         "roundsPerDay": {
           "key": "cm91bmRzUGVyRGF5",

--- a/examples/reti/artifacts/ValidatorRegistry.arc56_draft.json
+++ b/examples/reti/artifacts/ValidatorRegistry.arc56_draft.json
@@ -1171,7 +1171,7 @@
         "stakingPoolApprovalProgram": {
           "key": "cG9vbFRlbXBsYXRlQXBwcm92YWxCeXRlcw==",
           "keyType": "AVMBytes",
-          "valueType": "byte[]"
+          "valueType": "AVMBytes"
         }
       }
     },

--- a/src/lib/compiler.ts
+++ b/src/lib/compiler.ts
@@ -7719,7 +7719,7 @@ declare type AssetFreezeTxn = Required<AssetFreezeParams>;
         state.keys[sp.type][sp.name] = {
           key: Buffer.from(sp.key).toString('base64'),
           keyType: 'AVMBytes',
-          valueType: typeInfoToABIString(sp.valueType),
+          valueType: equalTypes(sp.valueType, StackType.bytes) ? 'AVMBytes' : typeInfoToABIString(sp.valueType),
         };
       } else {
         let keyType = equalTypes(sp.keyType, StackType.bytes) ? 'AVMBytes' : typeInfoToABIString(sp.keyType);

--- a/tests/contracts/artifacts/GeneralTest.arc56_draft.json
+++ b/tests/contracts/artifacts/GeneralTest.arc56_draft.json
@@ -1100,12 +1100,12 @@
         "pageOne": {
           "key": "cGFnZU9uZQ==",
           "keyType": "AVMBytes",
-          "valueType": "byte[]"
+          "valueType": "AVMBytes"
         },
         "pageTwo": {
           "key": "cGFnZVR3bw==",
           "keyType": "AVMBytes",
-          "valueType": "byte[]"
+          "valueType": "AVMBytes"
         }
       }
     },

--- a/tests/contracts/artifacts/StorageTest.arc56_draft.json
+++ b/tests/contracts/artifacts/StorageTest.arc56_draft.json
@@ -615,14 +615,14 @@
         "globalKey": {
           "key": "Zm9v",
           "keyType": "AVMBytes",
-          "valueType": "byte[]"
+          "valueType": "AVMBytes"
         }
       },
       "local": {
         "localKey": {
           "key": "Zm9v",
           "keyType": "AVMBytes",
-          "valueType": "byte[]"
+          "valueType": "AVMBytes"
         }
       },
       "box": {
@@ -634,7 +634,7 @@
         "boxKey": {
           "key": "Zm9v",
           "keyType": "AVMBytes",
-          "valueType": "byte[]"
+          "valueType": "AVMBytes"
         }
       }
     },


### PR DESCRIPTION
Properly sets the value type in ARC56 state key values to `AVMBytes` where appropriate